### PR TITLE
Laravel upgrade compability

### DIFF
--- a/src/Chumper/Datatable/DatatableServiceProvider.php
+++ b/src/Chumper/Datatable/DatatableServiceProvider.php
@@ -38,7 +38,7 @@ class DatatableServiceProvider extends ServiceProvider {
 
         $this->mergeConfigFrom(__DIR__.'/../../config/config.php', 'chumper.datatable');
 
-        $this->app->bind('datatable', function () {
+        $this->app->singleton('datatable', function () {
             return new Datatable;
         });
 

--- a/src/Chumper/Datatable/DatatableServiceProvider.php
+++ b/src/Chumper/Datatable/DatatableServiceProvider.php
@@ -38,8 +38,7 @@ class DatatableServiceProvider extends ServiceProvider {
 
         $this->mergeConfigFrom(__DIR__.'/../../config/config.php', 'chumper.datatable');
 
-        $this->app['datatable'] = $this->app->share(function($app)
-        {
+        $this->app->bind('datatable', function () {
             return new Datatable;
         });
 


### PR DESCRIPTION
Upgrading from Laravel 5.2 -> 5.5, this change is needed for the provider to continue working.